### PR TITLE
Fix conda windows

### DIFF
--- a/.github/workflows/pack-conda.yml
+++ b/.github/workflows/pack-conda.yml
@@ -1,0 +1,170 @@
+---
+    name: Conda Packages
+    on:
+      workflow_dispatch:
+      pull_request:
+        branches: 
+        - main
+    defaults:
+      run:
+        shell: bash -el {0}
+    jobs:
+      build:
+        strategy:
+          fail-fast: false
+          matrix:
+            setup:
+              - {os: ubuntu-22.04, os-family: linux-x64}
+              - {os: windows-2022, os-family: win-x64}
+              - {os: macos-13, os-family: osx-x64}
+              - {os: macos-14, os-family: osx-arm64}
+        runs-on: ${{ matrix.setup.os }}
+        steps:
+          - name: Checkout Sources
+            uses: actions/checkout@v4
+            # we need submodule for spkg 
+            # It must be set to recursive see https://github.com/microsoft/vcpkg/issues/25349#issuecomment-1162867135
+            with:
+                submodules: recursive
+                fetch-depth: 0
+          - name: Install Miniconda
+            uses: conda-incubator/setup-miniconda@v3
+            with:
+              miniforge-version: latest
+              python-version: '3.12'
+          - name: Install Dependency Requirements for Building Conda Packages
+            run: conda install -y conda-build
+          # We need MacOS SDK 10.10 to build for macOS Intel
+          # See: https://docs.conda.io/projects/conda-build/en/3.21.x/resources/compiler-tools.html#macos-sdk
+          - name: Install Mac OS SDK 10.10
+            if: runner.os == 'macOS'
+            run: |
+              wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.10.sdk.tar.xz
+              sudo tar -zxvf MacOSX10.10.sdk.tar.xz -C /opt
+          - name: Build conda packages 
+            run: |
+              conda build conda --output-folder ./builds/packages
+          - name: Upload conda packages artifact
+            uses: actions/upload-artifact@v4
+            with:
+              name: khiops-conda-${{ matrix.setup.os-family }}
+              path: ./builds/packages
+              retention-days: 7
+    #   # Test Conda package on brand new environments
+    #   test:
+    #     needs: build
+    #     strategy:
+    #       fail-fast: false
+    #       matrix:
+    #         env:
+    #           - {os: ubuntu-20.04, os-family: linux-64}
+    #           - {os: ubuntu-22.04, os-family: linux-64}
+    #           - {os: ubuntu-24.04, os-family: linux-64}
+    #           - {os: windows-2019, os-family: win-64}
+    #           - {os: windows-2022, os-family: win-64}
+    #           - {os: macos-12, os-family: osx-64}
+    #           - {os: macos-13, os-family: osx-64}
+    #           - {os: macos-14, os-family: osx-arm64}
+    #     runs-on: ${{ matrix.env.os }}
+    #     steps:
+    #       - name: Install Miniconda
+    #         uses: conda-incubator/setup-miniconda@v3
+    #         with:
+    #           miniconda-version: latest  # needed for macOS 13
+    #           python-version: ${{ matrix.python-version }}
+    #       - name: Download Conda Package Artifact
+    #         uses: actions/download-artifact@v4
+    #         with:
+    #           name: khiops-conda-${{ matrix.env.os-family }}
+    #           path: ./build/conda
+    #       - name: Install the Conda package (Windows)
+    #         if: runner.os == 'Windows'
+    #         run: conda install --channel ./build/conda khiops-core
+    #       # In Linux/macOS we need the conda-forge channel to install their pinned versions
+    #       - name: Install the Conda package (Linux/macOS)
+    #         if: runner.os != 'Windows'
+    #         run: |
+    #           conda install --channel conda-forge --channel ./build/conda khiops-core
+    #       - name: Add  CONDA_PREFIX to shared PATH
+    #         run: |
+    #           echo "$CONDA_PREFIX/bin" >> $GITHUB_PATH
+    #       - name: Checkout sources
+    #         uses: actions/checkout@v4
+    #       - name: Test that the executables are installed
+    #         uses: ./.github/actions/test-khiops-install
+    #       - name: Test that khiops on Iris dataset
+    #         uses: ./.github/actions/test-khiops-on-iris
+    
+    #   # Release is only executed on tags
+    #   # Note: For this job to work the secrets variables KHIOPS_ANACONDA_CHANNEL_TOKEN and
+    #   #       KHIOPS_DEV_ANACONDA_CHANNEL_TOKEN must be set with valid anaconda.org access tokens
+    #   release:
+    #     if: github.ref_type == 'tag'
+    #     needs: test
+    #     runs-on: ubuntu-22.04
+    #     permissions:
+    #       contents: write
+    #     steps:
+    #       - name: Download package artifacts
+    #         uses: actions/download-artifact@v4
+    #         with:
+    #           # See the upload-artifact step in the build job for the explanation of this pattern
+    #           path: ./build/conda
+    #           pattern: khiops-conda-*
+    #           merge-multiple: true
+    #       - name: Install Miniconda
+    #         uses: conda-incubator/setup-miniconda@v3
+    #         with:
+    #           miniconda-version: latest
+    #           python-version: '3.12'
+    #       - name: Install requirement packages
+    #         run: conda install -y anaconda-client conda-index
+    #       - name: Reindex the package directory
+    #         run: python -m conda_index ./build/conda
+    #       - name: Upload the packages to anaconda.org
+    #         run: |
+    #           # Set the anaconda.org channel
+    #           ANACONDA_CHANNEL="${{ inputs.release-channel || 'khiops-dev' }}"
+    
+    #           # For the release channel: upload without forcing; do not upload kni-transfer
+    #           if [[ "$ANACONDA_CHANNEL" == "khiops" ]]
+    #           then
+    #             rm -f -v ./build/conda/*/kni-transfer*.tar.bz2
+    #             anaconda --token "${{ secrets.KHIOPS_ANACONDA_CHANNEL_TOKEN }}" upload \
+    #               --user "$ANACONDA_CHANNEL" ./build/conda/*/*.tar.bz2
+    #           # For the dev channel: upload with forcing
+    #           else
+    #             anaconda --token "${{ secrets.KHIOPS_DEV_ANACONDA_CHANNEL_TOKEN }}" upload \
+    #               --user "$ANACONDA_CHANNEL" --force ./build/conda/*/*.tar.bz2
+    #           fi
+    #       - name: Extract package version
+    #         run: |
+    #           PKG_VERSION=$(\
+    #               conda search --override-channels --channel ./build/conda/ khiops-core \
+    #                 | awk '!/#|channels/ {print $2}' \
+    #                 | sort -u \
+    #           )
+    #           echo "PKG_VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
+    #       - name: Create the release zip archive
+    #         uses: thedoctor0/zip-release@0.7.6
+    #         with:
+    #           type: zip
+    #           path: ./build/conda
+    #           filename: khiops-${{ env.PKG_VERSION }}-conda.zip
+    #       - name: Upload conda package artifacts for all platforms
+    #         uses: actions/upload-artifact@v4
+    #         with:
+    #           name: khiops-conda-all
+    #           path: ./khiops-${{ env.PKG_VERSION }}-conda.zip
+    #       - name: Release the zip archive
+    #         uses: ncipollo/release-action@v1
+    #         with:
+    #           allowUpdates: true
+    #           body: |
+    #             **This release is for testing purposes only and there is no support for it.**
+    #             **Go to https://khiops.org to install the latest supported version.**
+    #           draft: false
+    #           makeLatest: false
+    #           prerelease: true
+    #           updateOnlyUnreleased: true
+    

--- a/.github/workflows/pack-debian.yml
+++ b/.github/workflows/pack-debian.yml
@@ -1,0 +1,63 @@
+---
+name: DEB Packages
+on:
+  workflow_dispatch:
+  pull_request:
+        branches: 
+        - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ['debian:10', 'debian:11', 'debian:12',  'ubuntu:20.04', 'ubuntu:22.04', 'ubuntu:24.04']
+    container: ${{ matrix.image }}
+    steps:
+      - name: Install packages
+        run: |
+          export DEBIAN_FRONTEND="noninteractive"
+          apt-get -y update
+          apt-get -y --no-install-recommends install build-essential coreutils debhelper git ca-certificates curl 
+          apt-get -y install ninja-build 
+          apt-get -y install zip pkg-config # for vcpkkg
+          curl -LO "https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.sh"
+          bash cmake-3.30.3-linux-x86_64.sh --prefix=/usr/local/ --exclude-subdir
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Configure CMake
+        run: |
+          cmake -B builds -S . -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
+      - name: Build 
+        run: |
+          cmake --build builds --target khiopsdriver_file_s3
+      - name: Build package with CPack
+        run: cd builds/ && cpack -G DEB
+      - name: Set environment variables
+        run: |
+          source /etc/os-release
+          echo "ID=$ID" >> "$GITHUB_ENV"
+          echo "VERSION_CODENAME=$VERSION_CODENAME" >> "$GITHUB_ENV"
+      - name: Rename the packages to include the ubuntu codename
+        run: |
+          cd builds/packages/
+          for filename in *.deb
+          do
+            mv -v $filename ${filename%_*}-${VERSION_CODENAME}.${filename##*_}
+          done
+      - name: Upload the packages as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          # We add a `deb-` prefix so we can later recover all artifacts with the pattern `deb-*`
+          # Note: The more natural pattern `*-deb` or `*` does not work
+          name: deb-${{ env.ID }}-${{ env.VERSION_CODENAME }}
+          path: builds/packages/*.deb
+          if-no-files-found: error
+ 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,9 @@ endif(BUILD_TESTS)
 
 add_subdirectory(test)
 
-include(GNUInstallDirs)
 install(
   TARGETS khiopsdriver_file_s3
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIB}
+  LIBRARY DESTINATION "lib"
   ARCHIVE # lib on windows
   RUNTIME # dll on windows
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,11 @@ cmake_minimum_required(VERSION 3.20)
 # Enforce c++11 standard.
 set(CMAKE_CXX_STANDARD 11)
 
-project(khiops-s3 LANGUAGES CXX)
+project(khiops-s3 LANGUAGES CXX VERSION 0.1.0)
+
+# Exclude googletest from the installation and packages
+set(INSTALL_GTEST OFF)
+set(INSTALL_GMOCK OFF)
 
 include(GoogleTest)
 enable_testing()
@@ -79,6 +83,9 @@ target_compile_options(
     $<$<CXX_COMPILER_ID:MSVC>:-Wall;/wd4582;/wd4583;/wd4625;/wd4626;/wd4710;/wd4711;/wd4820;/wd4868>
   PRIVATE $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wall;-Wextra;-pedantic>)
 
+set_target_properties(khiopsdriver_file_s3 PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR} VERSION ${PROJECT_VERSION})
+
+
 option(BUILD_TESTS "Build test programs" OFF)
 
 if(BUILD_TESTS)
@@ -89,3 +96,89 @@ if(BUILD_TESTS)
 endif(BUILD_TESTS)
 
 add_subdirectory(test)
+
+include(GNUInstallDirs)
+install(
+  TARGETS khiopsdriver_file_s3
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIB}
+  ARCHIVE # lib on windows
+  RUNTIME # dll on windows
+)
+
+set(CPACK_PACKAGE_VENDOR Orange)
+set(CPACK_PACKAGE_HOMEPAGE_URL https://khiops.org)
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+set(CPACK_PACKAGE_VENDOR "Orange")
+set(CPACK_PACKAGE_CONTACT "Khiops Team <khiops.team@orange.com>")
+set(CPACK_SOURCE_IGNORE_FILES .git)
+set(CPACK_PACKAGE_DESCRIPTION "This driver allows Khiops to access the Amazon S3 Cloud storage.")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "S3 driver for the Khiops tool")
+set(CPACK_PACKAGE_NAME "khiops-driver-s3")
+
+set(CPACK_VERBATIM_VARIABLES YES)
+set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
+set(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_BINARY_DIR}/packages")
+# set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/")
+
+# ########### ARCHIVE Generator #############################
+
+# One package per component
+set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+
+# user friendly archive names
+set(CPACK_ARCHIVE_FILE_NAME khiops-driver-s3-${PROJECT_VERSION})
+
+# ########### DEB Generator #############################
+
+# Package release ("This is the numbering of the DEB package itself, i.e. the version of the packaging and not the
+# version of the content")
+set(CPACK_DEBIAN_PACKAGE_RELEASE 1)
+
+# package name for deb.
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+
+# Packages version: the full KHIOPS_VERSION (N.N.N_aN) instead of the PROJECT_VERSION (N.N.N)
+# set(CPACK_DEBIAN_PACKAGE_VERSION ${KHIOPS_VERSION})
+
+set(CPACK_DEB_COMPONENT_INSTALL YES)
+set(CPACK_DEBIAN_PACKAGE_SECTION "math")
+
+# runtime path setting
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)
+# binaries in deb building will search shared library in the build tree. We should use directly
+# CMAKE_LIBRARY_OUTPUT_DIRECTORY but it produces a bug in dpkg-shlibdeps
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS ${CMAKE_BINARY_DIR}/lib/)
+
+# packages recommends
+set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "khiops")
+
+# packages posinst and triggers set(CPACK_DEBIAN_KNI_PACKAGE_CONTROL_EXTRA
+# ${PROJECT_SOURCE_DIR}/packaging/linux/debian/kni/triggers")
+
+# set(CPACK_DEBIAN_PACKAGE_DEBUG ON)
+set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
+
+# ########### RPM Generator #############################
+
+set(CPACK_RPM_COMPONENT_INSTALL ON)
+set(CPACK_RPM_PACKAGE_LICENSE BSD-3-Clause)
+set(CPACK_RPM_PACKAGE_GROUP "Applications/Engineering")
+set(CPACK_RPM_PACKAGE_VENDOR Orange)
+
+set(CPACK_RPM_KHIOPS_PACKAGE_AUTOREQ ON)
+
+# Packages version set(CPACK_RPM_PACKAGE_VERSION ${PROJECT_VERSION})
+
+# packages names set(CPACK_RPM_PACKAGE_NAME khiops)
+
+# default file name e.g. khiops-10.0.0-1.x86_64.rpm
+set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
+
+# packages summary set(CPACK_RPM_PACKAGE_SUMMARY "Khiops tools")
+
+# packages post/postun install scripts set(CPACK_RPM_KNI_POST_INSTALL_SCRIPT_FILE
+# "${PROJECT_SOURCE_DIR}/packaging/linux/redhat/kni.post") set(CPACK_RPM_KNI_POSTUN_INSTALL_SCRIPT_FILE
+# "${PROJECT_SOURCE_DIR}/packaging/linux/redhat/kni.postun")
+
+include(CPack)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,32 @@
+The Clear BSD License
+
+Copyright (c) 2024 Orange S.A.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the disclaimer
+below) provided that the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,0 +1,18 @@
+REM Echo all output
+@echo on
+
+REM We need to use the subst command to shorten the paths:  
+REM "aws-sdk-cpp's buildsystem uses very long paths and may fail on your system. 
+REM We recommend moving vcpkg to a short path such as 'C:\src\vcpkg' or using the subst command."
+subst W: %CD% 
+W:
+vcpkg\vcpkg.exe install
+
+REM Configure project
+cmake --fresh -G Ninja -D CMAKE_BUILD_TYPE=Release -D VCPKG_BUILD_TYPE=release -D CMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake -B builds/conda -S .
+
+REM Build
+cmake --build builds/conda --target khiopsdriver_file_s3
+
+REM Copy binary to conda package
+cmake --install builds/conda --prefix $PREFIX

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Set-up the shell to behave more like a general-purpose programming language
+set -euo pipefail
+
+# Configure project
+cmake --fresh -G Ninja -D CMAKE_BUILD_TYPE=Release -D VCPKG_BUILD_TYPE=release -D CMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake -B builds/conda -S .
+
+# Build
+cmake --build builds/conda --target khiopsdriver_file_s3
+
+# Copy binary to conda package
+cmake --install builds/conda --prefix $PREFIX
+
+
+
+

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,0 +1,20 @@
+---
+c_compiler:
+  - gcc # [linux]
+  - clang # [osx]
+  - vs2022 # [win]
+c_compiler_version:
+  - 12 # [linux]
+  - 16 # [osx]
+cxx_compiler:
+  - gxx # [linux]
+  - clangxx # [osx]
+  - vs2022 # [win]
+cxx_compiler_version:
+  - 12 # [linux]
+  - 16 # [osx]
+# We need MacOS SDK 10.10 to be able to build on macOS Intel
+# Download: https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.10.sdk.tar.xz
+# Decompress then to /opt: tar -zxvf MacOSX10.10.sdk.tar.xz -C /opt
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.10.sdk # [osx and not arm64]

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: khiops-driver-s3
+  version: 0.0.1
+
+source:
+  path: ../
+
+build:
+  number: 0
+requirements:
+  build:
+    - cmake
+    - ninja
+    - {{ compiler('cxx') }}
+
+files:
+  - lib/libkhiopsdriver_file_s3.so*
+
+about:
+  home: https://khiops.org
+  license: BSD+3-clause
+  summary: Khiops driver to access files on Amazon S3
+  doc_url: https://khiops.org
+  dev_url: https://github.com/khiopsml/khiops


### PR DESCRIPTION
The cmake module GNUInstallDirs doesn't provide a valide library location.
It is better and simpler to use "lib" for both UNIXes and windows